### PR TITLE
Convert to package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+dist/*
+*.egg-info/*

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,3 @@
-include README.md
-recursive-include static *
-recursive-include templates *
-recursive-include tests *.xmi
+graft .
+graft static
+graft templates

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,4 @@
+include README.md
+recursive-include static *
+recursive-include templates *
+recursive-include tests *.xmi

--- a/setup.py
+++ b/setup.py
@@ -1,51 +1,41 @@
 #!/usr/bin/env python2.7
-
+import os
 import subprocess
-version = subprocess.check_output(["git", "describe", "--tags", "--always"])[:-1]
+VERSION = subprocess.check_output(["git", "describe", "--tags", "--always"])[:-1]
 
 try:
-	from setuptools import setup
+    from setuptools import setup
 except ImportError:
-	print "Cannot find setuptools; dependencies will not be installed."
-	from distutils.core import setup
-import os 
+    print "Cannot find setuptools; dependencies will not be installed."
+    from distutils.core import setup
+
+
 def gen_data_files(*dirs):
     results = []
 
     for src_dir in dirs:
-        for root,dirs,files in os.walk(src_dir):
-            for f in files:
-            	results.append(root + "/" + f)
+        for root, dirs, files in os.walk(src_dir):
+            for file_name in files:
+                results.append(root + "/" + file_name)
     return {'': results}
 
+
 setup(
-	name="tango-website-plugin-dsc",
-	version=version,
-	description="Device Server Catalogue for Tango Controls website",
-	author="Tango Community",
-	author_email="contact@tango-controls.org",
-	url="http://www.tango-controls.org/developers/dsc/",
-	packages=[
-		"dsc",
-		"dsc.migrations",
-		"dsc.scripts",
-		"dsc.templatetags",
-		"dsc.tests"
-	],
-	package_dir={"dsc": "."},
-        package_data=gen_data_files('templates', 'static'),
-	# package_data={"dsc": [
-	# 	"README.md",
-	# 	"static/*/*",
-	# 	"templates/*/*",
-	# 	"tests/*.xmi"
-	# ]},
-	# data_files={"dsc": [
-	# 	"README.md",
-	# 	"static/*",
-	# 	"templates/*",
-	# 	"tests/*.xmi"
-	# ]},
-	include_package_data=True,
-	zip_safe=False
+    name="tango-website-plugin-dsc",
+    version=VERSION,
+    description="Device Server Catalogue for Tango Controls website",
+    author="Tango Community",
+    author_email="contact@tango-controls.org",
+    url="http://www.tango-controls.org/developers/dsc/",
+    packages=[
+        "dsc",
+        "dsc.migrations",
+        "dsc.scripts",
+        "dsc.templatetags",
+        "dsc.tests"
+    ],
+    package_dir={"dsc": "."},
+    package_data=gen_data_files('templates', 'static'),
+    include_package_data=True,
+    zip_safe=False
 )

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ def gen_data_files(*dirs):
     for src_dir in dirs:
         for root, dirs, files in os.walk(src_dir):
             for file_name in files:
-                results.append(root + "/" + file_name)
+                results.append(os.path.join(root, file_name))
     return {'': results}
 
 

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,15 @@ try:
 except ImportError:
 	print "Cannot find setuptools; dependencies will not be installed."
 	from distutils.core import setup
+import os 
+def gen_data_files(*dirs):
+    results = []
 
+    for src_dir in dirs:
+        for root,dirs,files in os.walk(src_dir):
+            for f in files:
+            	results.append(root + "/" + f)
+    return {'': results}
 
 setup(
 	name="tango-website-plugin-dsc",
@@ -25,6 +33,7 @@ setup(
 		"dsc.tests"
 	],
 	package_dir={"dsc": "."},
+        package_data=gen_data_files('templates', 'static'),
 	# package_data={"dsc": [
 	# 	"README.md",
 	# 	"static/*/*",

--- a/setup.py
+++ b/setup.py
@@ -18,13 +18,13 @@ setup(
 	author_email="contact@tango-controls.org",
 	url="http://www.tango-controls.org/developers/dsc/",
 	packages=[
-		"tango_dsc",
-		"tango_dsc.migrations",
-		"tango_dsc.scripts",
-		"tango_dsc.templatetags",
-		"tango_dsc.tests"
+		"dsc",
+		"dsc.migrations",
+		"dsc.scripts",
+		"dsc.templatetags",
+		"dsc.tests"
 	],
-	package_dir={"tango_dsc": "."},
+	package_dir={"dsc": "."},
 	include_package_data=True,
 	zip_safe=False
 )

--- a/setup.py
+++ b/setup.py
@@ -25,6 +25,18 @@ setup(
 		"dsc.tests"
 	],
 	package_dir={"dsc": "."},
+	# package_data={"dsc": [
+	# 	"README.md",
+	# 	"static/*/*",
+	# 	"templates/*/*",
+	# 	"tests/*.xmi"
+	# ]},
+	# data_files={"dsc": [
+	# 	"README.md",
+	# 	"static/*",
+	# 	"templates/*",
+	# 	"tests/*.xmi"
+	# ]},
 	include_package_data=True,
 	zip_safe=False
 )

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python2.7
+
+import subprocess
+version = subprocess.check_output(["git", "describe", "--tags", "--always"])[:-1]
+
+try:
+	from setuptools import setup
+except ImportError:
+	print "Cannot find setuptools; dependencies will not be installed."
+	from distutils.core import setup
+
+
+setup(
+	name="tango-website-plugin-dsc",
+	version=version,
+	description="Device Server Catalogue for Tango Controls website",
+	author="Tango Community",
+	author_email="contact@tango-controls.org",
+	url="http://www.tango-controls.org/developers/dsc/",
+	packages=[
+		"tango_dsc",
+		"tango_dsc.migrations",
+		"tango_dsc.scripts",
+		"tango_dsc.templatetags",
+		"tango_dsc.tests"
+	],
+	package_dir={"tango_dsc": "."},
+	include_package_data=True,
+	zip_safe=False
+)


### PR DESCRIPTION
Add files necessary to build Python package.

To install, run `python setup.py install`.
After that change entry in Tango website's `INSTALLED_APPS` (in `settings.py`) from `dsc` to `tango_dsc` and remove DSC source tree from the Tango website.

Closes #15